### PR TITLE
fixed #213 ui-datepicker use quick-pick get error : Uncaught TypeError

### DIFF
--- a/src/lib/components/datepicker/index.vue
+++ b/src/lib/components/datepicker/index.vue
@@ -1006,7 +1006,8 @@ export default {
 
                 this._set(formatDate(date, this.conf.format));
 
-                if (this.$slots.timepicker[0] &&
+                if (this.$slots.timepicker &&
+                    this.$slots.timepicker[0] &&
                     this.$slots.timepicker[0].children &&
                     this.$slots.timepicker[0].children[0]) {
 
@@ -1028,7 +1029,8 @@ export default {
                     formatDate(date[1], this.conf.format)
                 ]);
 
-                if (this.$slots.timepicker[0] &&
+                if (this.$slots.timepicker &&
+                    this.$slots.timepicker[0] &&
                     this.$slots.timepicker[0].children &&
                     this.$slots.timepicker[0].children[0]) {
 
@@ -1038,7 +1040,8 @@ export default {
 
                 }
 
-                if (this.$slots.timepicker2[0] &&
+                if (this.$slots.timepicker2 &&
+                    this.$slots.timepicker2[0] &&
                     this.$slots.timepicker2[0].children &&
                     this.$slots.timepicker2[0].children[0]) {
 


### PR DESCRIPTION
首先感谢你的贡献！

__检查清单__

请在提交PR之前检测以下项目：

- [x] 你的分支是从`dev`分支切出并请求合入`dev`，分支名符合格式：`issue-[issue id]`。
- [x] 运行`npm run lint`并在提交之前修正这些错误以保持一致的代码风格。
- [x] 运行`npm run test`并通过所有的测试。
- [x] 为你RP添加简洁清晰的说明。

如果这是一次问题修复：

- [ ] 确保为你修复的问题添加至少一个测试用例，避免它再次发生

如果这是一个新功能或改进：

- [ ] 更新对应的文档，如有必要添加了此功能的演示
- [ ] 添加测试

__说明__

修复`ui-datepicker`中启用`quick-pick`会报错(Uncaught TypeError: Cannot read property '0' of undefined)的问题