### PR TITLE
fixed #233 use reserved HTML elements as component id

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+docs/**/* linguist-documentation
+dist/* linguist-generated
+report/**/* linguist-generated

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -204,6 +204,8 @@ morning.install = function (Vue, options) {
         let creater = components[name];
         let component;
 
+        creater.name = `morning-${creater.name}`;
+
         if (creater.origin === 'UI') {
 
             component = this._origin.UI.extend(creater);
@@ -219,16 +221,16 @@ morning.install = function (Vue, options) {
         }
 
         if (!component.private) {
-           
-            Vue.component(`${options.prefix}-${component.options.name}`, component);
+
+            Vue.component(`${options.prefix}-${name}`, component);
 
         }
 
-        Vue.component(`morning-${component.options.name}`, component);
+        Vue.component(component.options.name, component);
 
         this._components[name] = component;
-        this._ignoreElements.push(`mor-${component.options.name}`);
-        this._ignoreElements.push(`morning-${component.options.name}`);
+        this._ignoreElements.push(`mor-${name}`);
+        this._ignoreElements.push(component.options.name);
 
     }
 

--- a/test/unit/components/action.js
+++ b/test/unit/components/action.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/apparent.js
+++ b/test/unit/components/apparent.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/article.js
+++ b/test/unit/components/article.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/badge.js
+++ b/test/unit/components/badge.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/block.js
+++ b/test/unit/components/block.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/box.js
+++ b/test/unit/components/box.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/btn.js
+++ b/test/unit/components/btn.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/btngroup.js
+++ b/test/unit/components/btngroup.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/capitalize.js
+++ b/test/unit/components/capitalize.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/card.js
+++ b/test/unit/components/card.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/center.js
+++ b/test/unit/components/center.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/del.js
+++ b/test/unit/components/del.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/divider.js
+++ b/test/unit/components/divider.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/dl.js
+++ b/test/unit/components/dl.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/em.js
+++ b/test/unit/components/em.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/formgroup.js
+++ b/test/unit/components/formgroup.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/grid.js
+++ b/test/unit/components/grid.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/h.js
+++ b/test/unit/components/h.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/header.js
+++ b/test/unit/components/header.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/il.js
+++ b/test/unit/components/il.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/img.js
+++ b/test/unit/components/img.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/itemlist.js
+++ b/test/unit/components/itemlist.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/jumbotron.js
+++ b/test/unit/components/jumbotron.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/label.js
+++ b/test/unit/components/label.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/lead.js
+++ b/test/unit/components/lead.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/lowercase.js
+++ b/test/unit/components/lowercase.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/mark.js
+++ b/test/unit/components/mark.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/ol.js
+++ b/test/unit/components/ol.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/quote.js
+++ b/test/unit/components/quote.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/select.js
+++ b/test/unit/components/select.js
@@ -25,7 +25,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/small.js
+++ b/test/unit/components/small.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/statistic.js
+++ b/test/unit/components/statistic.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/strong.js
+++ b/test/unit/components/strong.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/tab.js
+++ b/test/unit/components/tab.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/textarea.js
+++ b/test/unit/components/textarea.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/textcenter.js
+++ b/test/unit/components/textcenter.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/textcolor.js
+++ b/test/unit/components/textcolor.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/textinput.js
+++ b/test/unit/components/textinput.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/textleft.js
+++ b/test/unit/components/textleft.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/textright.js
+++ b/test/unit/components/textright.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/u.js
+++ b/test/unit/components/u.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/ul.js
+++ b/test/unit/components/ul.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 

--- a/test/unit/components/uppercase.js
+++ b/test/unit/components/uppercase.js
@@ -23,7 +23,7 @@ test('base : init component', async t => {
     t.plan(2);
 
     t.is(vm.uiid, 2);
-    t.is(component.options.name, name);
+    t.is(component.options.name, `morning-${name}`);
 
 });
 


### PR DESCRIPTION
首先感谢你的贡献！

__检查清单__

请在提交PR之前检测以下项目：

- [x] 你的分支是从`dev`分支切出并请求合入`dev`，分支名符合格式：`issue-[issue id]`。
- [x] 运行`npm run lint`并在提交之前修正这些错误以保持一致的代码风格。
- [x] 运行`npm run test`并通过所有的测试。
- [x] 为你RP添加简洁清晰的说明。

如果这是一次问题修复：

- [ ] 确保为你修复的问题添加至少一个测试用例，避免它再次发生

如果这是一个新功能或改进：

- [ ] 更新对应的文档，如有必要添加了此功能的演示
- [ ] 添加测试

__说明__

修复Vue警告(Do not use built-in or reserved HTML elements as component id)