### PR TITLE
fixed #421 ui-message show-type config set to topleft, message not show

### DIFF
--- a/src/docs/pages/component/message/index.vue
+++ b/src/docs/pages/component/message/index.vue
@@ -18,8 +18,8 @@
 
     - 仅消息 : 调用消息组件的`.push(message)`方法并传入一个字符串座位消息内容。
     - 有标题或配色 : 调用消息组件的`.push(option)`方法传入一个配置对象，对象的属性包括：
-        - `title` : 消息标题(String，可选)，若为空则不显示消息的标题
-        - `message` : 消息内容(String，必需)
+        - `title` : 消息标题(String，可选，不支持HTML)，若为空则不显示消息的标题
+        - `message` : 消息内容(String，必需，支持HTML)
         - `color` : 消息的配色(String，可选，默认`theme`配色)，支持[形态/颜色](/guide/status.html#颜色)中的所有颜色。
 
     > 使用时应注意，消息组件仅用于向用户传到信息，不应该包括可交互的行动元素。
@@ -52,6 +52,15 @@
     <div>
         <ui-message ref="demo1"></ui-message>
         <ui-link js="window.morning.findVM('demo1').push({color:'success', message: '这是消息的内容'});">推送一条消息</ui-link>
+    </div>
+    :::
+
+    #### 消息内容使用HTML
+
+    :::democode/html
+    <div>
+        <ui-message ref="demo18"></ui-message>
+        <ui-link js="window.morning.findVM('demo18').push('<i class=\'mo-icon mo-icon-warn-f\' style=\'font-size:32px;width:100%;display:inline-block;text-align:center;\'></i><br><br><b>一条新消息('+new Date()+')</b>');">推送一条新消息</ui-link>
     </div>
     :::
 

--- a/src/lib/components/message/index.less
+++ b/src/lib/components/message/index.less
@@ -14,7 +14,7 @@ mor-message{
         transform: translateX(-50%);
     }
 
-    &.pos-tf{
+    &.pos-tl{
         top: 0;
         left: @fontSize*0.5;
         width: 50%;


### PR DESCRIPTION
首先感谢你的贡献！

__检查清单__

请在提交PR之前检测以下项目：

- [x] 你的分支是从`dev`分支切出并请求合入`dev`，分支名符合格式：`issue-[issue id]`。
- [x] 运行`npm run lint`并在提交之前修正这些错误以保持一致的代码风格。
- [x] 运行`npm run test`并通过所有的测试。
- [x] 为你RP添加简洁清晰的说明。

如果这是一次问题修复：

- [ ] 确保为你修复的问题添加至少一个测试用例，避免它再次发生

如果这是一个新功能或改进：

- [ ] 更新对应的文档，如有必要添加了此功能的演示
- [ ] 添加测试

__说明__

修复`ui-message`组件的`show-type`配置为`topleft`时，消息不会显示的问题